### PR TITLE
Generate Property Tiles

### DIFF
--- a/cloud/generate_property_tiles_docker/DEPLOY.md
+++ b/cloud/generate_property_tiles_docker/DEPLOY.md
@@ -1,0 +1,42 @@
+## Deploying
+
+_generate_property_tiles_:
+
+## Deploy container and create job. 
+```shell
+gcloud run jobs deploy generate-property-tiles `
+  --service-account data-pipeline-user@musa5090s25-team4.iam.gserviceaccount.com `
+  --cpu 4 `
+  --memory 4Gi `
+  --region us-east4 `
+  --source .
+```
+
+## Execute job
+```shell
+gcloud run jobs execute generate-property-tiles --region us-east4
+```
+
+
+#### OLD: Only needed once when creating new job
+```shell
+gcloud artifacts repositories create generate-property-tiles --repository-format=docker `
+--location=us-central1
+```
+
+#### OLD: Do whenever docker build is changed
+```shell
+gcloud builds submit `
+  --region us-central1 `
+  --tag us-central1-docker.pkg.dev/musa5090s25-team4/generate-property-tiles/tiles-image:1
+```
+
+## OLD: Change to update/create depending on if job already exists
+```shell
+gcloud run jobs update generate-property-tiles `
+  --image us-central1-docker.pkg.dev/musa5090s25-team4/run-model/test-image:tag1 `
+  --service-account data-pipeline-user@musa5090s25-team4.iam.gserviceaccount.com `
+  --cpu 4 `
+  --memory 4Gi `
+  --region us-central1
+```

--- a/cloud/generate_property_tiles_docker/Dockerfile
+++ b/cloud/generate_property_tiles_docker/Dockerfile
@@ -1,0 +1,26 @@
+# This Dockerfile is a mix of two documentation sources:
+# https://cloud.google.com/run/docs/quickstarts/jobs/build-create-shell#writing
+# https://cloud.google.com/run/docs/tutorials/gcloud#code-container
+
+# ----------
+
+# Use a gcloud image based on debian:buster-slim for a lean production container.
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+
+RUN apt-get update
+
+# Install GDAL for ogr2ogr
+RUN apt-get install -y gdal-bin
+
+# Execute next commands in the directory /workspace
+WORKDIR /workspace
+
+# Copy over the script to the /workspace directory
+COPY script.sh .
+
+# Just in case the script doesn't have the executable bit set
+RUN chmod +x ./script.sh
+
+# Run the script when starting the container
+CMD [ "./script.sh" ]

--- a/cloud/generate_property_tiles_docker/script.sh
+++ b/cloud/generate_property_tiles_docker/script.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -ex
+
+# Download the property_tile_info.geojson file from the temp bucket.
+gcloud storage cp \
+  gs://musa5090s25-team4-temp_data/property_tile_info.geojson \
+  ./property_tile_info.geojson
+
+# Convert the geojson file to a vector tileset in a folder named "properties".
+# The tile set will be in the range of zoom levels 12-18. See the ogr2ogr docs
+# at https://gdal.org/drivers/vector/mvt.html for more information.
+ogr2ogr \
+  -f MVT \
+  -dsco MINZOOM=12 \
+  -dsco MAXZOOM=18 \
+  -dsco COMPRESS=NO \
+  ./properties \
+  ./property_tile_info.geojson
+
+# Upload the vector tileset to the public bucket.
+gcloud storage cp \
+  --recursive \
+  ./properties \
+  gs://musa5090s25-team4-public/tiles

--- a/cloud/generate_tile_info/.gcloudignore
+++ b/cloud/generate_tile_info/.gcloudignore
@@ -1,0 +1,10 @@
+# Node or Python generated files
+node_modules/
+env/
+*.pyc
+
+# Data generated while testing
+*.[csv|zip|gpkg|json|jsonl]
+
+# The .gcloudignore file itself
+.gcloudignore

--- a/cloud/generate_tile_info/DEPLOY.md
+++ b/cloud/generate_tile_info/DEPLOY.md
@@ -1,0 +1,26 @@
+## Deploying
+
+
+#### Reformats opa property data from csv to jsonl and reprojects geometry from epsg:2272 to epsg:4326
+#### Reads from raw data bucket and writes to prepared data bucket
+_prepare_phl_opa_properties_:
+
+#### Deploy cloud function: prepare_phl_opa_properties
+```shell
+gcloud functions deploy generate_tile_info `
+--gen2 `
+--region=us-east4 `
+--runtime=python312 `
+--source=. `
+--entry-point=generate_tile_info `
+--service-account=data-pipeline-user@musa5090s25-team4.iam.gserviceaccount.com `
+--memory=8Gi `
+--timeout=480s `
+--trigger-http `
+--no-allow-unauthenticated
+```
+
+#### Execute cloud function: generate_tile_info
+```shell
+gcloud functions call generate_tile_info --region=us-east4
+```

--- a/cloud/generate_tile_info/main.py
+++ b/cloud/generate_tile_info/main.py
@@ -1,0 +1,79 @@
+from dotenv import load_dotenv
+load_dotenv()
+
+import csv
+import json
+import os
+import pathlib
+
+import functions_framework
+from google.cloud import storage
+from google.cloud import bigquery
+
+DIR_NAME = pathlib.Path(__file__).parent
+
+
+# Main function used to prepare opa property data
+# Reads phl_opa_properties.csv from raw data bucket
+# Reprojects geometry from epsg:2272 to epsg:4326
+# Writes phl_opa_properties.jsonl into the prepared data bucket
+@functions_framework.http
+def generate_tile_info(request):
+    print('Generating Property Tile Info...')
+
+    # Read the SQL file specified in the request
+    sql_path = DIR_NAME / 'sql' / 'get_tile_info.sql'
+
+    # Check that the file exists
+    if (not sql_path.exists()) or (not sql_path.is_file()):
+        # Return a 404 (not found) response if not
+        return f'File {sql_path} not found', 404
+
+    # Read the SQL file
+    with open(sql_path, 'r', encoding='utf-8') as sql_file:
+        sql_query = sql_file.read()
+
+    # Run the SQL query
+    bigquery_client = bigquery.Client()
+
+    rows = bigquery_client.query_and_wait(sql_query)  # Make an API request.
+
+    tile_features = [{
+          "type": "Feature",
+          "geometry": json.loads(row["geometry"]),
+          "properties": {
+            "address": row["address"],
+            "current_assessed_value": round(row["current_assessed_value"]),
+            "tax_year_assessed_value": round(row["tax_year_assessed_value"])
+          }
+        } for row in rows]
+    
+    property_tiles = {
+        "type": "FeatureCollection",
+        "name": "PropertyTiles",
+        "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"}},
+        "features": tile_features
+    }
+
+    property_tiles_json = json.dumps(property_tiles)
+
+    property_tile_info_filename = DIR_NAME / 'property_tile_info.geojson'
+
+    output_bucket_name = 'musa5090s25-team4-temp_data'
+
+    with open(property_tile_info_filename, 'w') as f:
+        f.write(property_tiles_json)
+
+    storage_client = storage.Client()
+    output_data_bucket = storage_client.bucket(output_bucket_name)
+
+    print(f'Processed data into {property_tile_info_filename}')
+
+    # Upload the tile info data to the bucket
+    output_blobname = 'property_tile_info.geojson'
+    blob = output_data_bucket.blob(output_blobname)
+
+    blob.upload_from_filename(property_tile_info_filename)
+    print(f'Uploaded to {property_tile_info_filename}')
+
+    return f'Processed data into {property_tile_info_filename} and uploaded to gs://{output_bucket_name}/{property_tile_info_filename}'

--- a/cloud/generate_tile_info/main.py
+++ b/cloud/generate_tile_info/main.py
@@ -42,6 +42,7 @@ def generate_tile_info(request):
           "type": "Feature",
           "geometry": json.loads(row["geometry"]),
           "properties": {
+            "property_id": row["property_id"],
             "address": row["address"],
             "current_assessed_value": round(row["current_assessed_value"]),
             "tax_year_assessed_value": round(row["tax_year_assessed_value"])
@@ -50,7 +51,7 @@ def generate_tile_info(request):
     
     property_tiles = {
         "type": "FeatureCollection",
-        "name": "PropertyTiles",
+        "name": "property_tile_info",
         "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"}},
         "features": tile_features
     }

--- a/cloud/generate_tile_info/requirements.txt
+++ b/cloud/generate_tile_info/requirements.txt
@@ -1,0 +1,6 @@
+functions_framework==3.5.0
+google-cloud-bigquery==3.18.0
+google-cloud-storage==2.16.0
+pyproj==3.6.1
+python-dotenv==1.0.1
+Shapely==2.0.3

--- a/cloud/generate_tile_info/sql/get_tile_info.sql
+++ b/cloud/generate_tile_info/sql/get_tile_info.sql
@@ -1,0 +1,16 @@
+SELECT 
+    phl_properties.property_id,
+    location AS address,
+    CAST(model_assessment.price AS NUMERIC) AS current_assessed_value,
+    CAST(phl_assessment.market_value AS NUMERIC) AS tax_year_assessed_value,
+    ST_ASGEOJSON(geometry) AS geometry
+FROM `musa5090s25-team4.derived.model_assessment_output` AS model_assessment
+INNER JOIN (
+  select 
+    property_id,
+    market_value
+  from `musa5090s25-team4.core.phl_opa_assessments`
+  where year = '2024'
+) AS phl_assessment ON model_assessment.property_id = phl_assessment.property_id
+INNER JOIN `musa5090s25-team4.core.phl_opa_properties` AS phl_properties ON model_assessment.property_id = phl_properties.property_id 
+INNER JOIN `musa5090s25-team4.core.phl_pwd_parcels` AS pwd_parcels ON model_assessment.property_id = pwd_parcels.property_id


### PR DESCRIPTION
# Description

This generates the property tile information geojson in the temp folder. This geojson is then read and used to create the map vector tiles in the public folder.
Resolves #6 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Small fix/change
- [ ] Documentation

## What should the reviewer know?

Deploy and execute the scripts using the code in the DEPLOY.md.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a `gcloud` command to upload to GCP)._

- [x] No action required
- [ ] Actions required (specified below)
