### PR TITLE
add assessment viewer widget

### DIFF
--- a/widget/index.html
+++ b/widget/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Assessment Widget</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <main class="widget-container">
+    <header class="widget-header">
+      <h2>Property Historical Assessment Viewer</h2>
+      <div class="opa-input">
+        <label for="opa-id">OPA&nbsp;ID</label>
+        <input type="text" id="opa-id" placeholder="e.g., 884265200" />
+        <button onclick="lookupAssessment()">Find</button>
+      </div>
+    </header>
+
+    <section class="valuation-summary">
+      <div id="valuation-chart-container">
+        <canvas id="valuation-chart"></canvas>
+      </div>
+      <div id="valuation-table-container"><!-- Table inserted by JS --></div>
+    </section>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/widget/script.js
+++ b/widget/script.js
@@ -1,0 +1,92 @@
+// Utility — currency formatter
+const fmt = new Intl.NumberFormat('en-US', {
+    style: 'currency', currency: 'USD', minimumFractionDigits: 0
+  });
+  
+  async function lookupAssessment () {
+    const opaId = document.getElementById('opa-id').value.trim();
+    if (!opaId) {
+      alert('Please enter a valid OPA ID');
+      return;
+    }
+  
+    // UI: disable button while loading
+    const btn = document.querySelector('.opa-input button');
+    const original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Loading…';
+  
+    try {
+      const url  = `https://api.phila.gov/opa/v1.1/property/${opaId}?format=json`;
+      const res  = await fetch(url);
+      if (!res.ok) throw new Error('No record found for that OPA ID');
+  
+      const json = await res.json();
+      const hist = json.data?.[0]?.assessment_history ?? [];
+      if (!hist.length) throw new Error('No assessment history available');
+  
+      // Sort ascending by year so the chart flows L→R chronologically
+      hist.sort((a, b) => a.year - b.year);
+  
+      const years  = hist.map(d => d.year);
+      const values = hist.map(d => d.market_value);
+  
+      renderChart(years, values);
+      renderTable(hist);
+    } catch (err) {
+      alert(err.message);
+      console.error(err);
+    } finally {
+      btn.disabled = false;
+      btn.textContent = original;
+    }
+  }
+  
+  function renderChart (labels, data) {
+    // Rebuild canvas if needed
+    if (!document.getElementById('valuation-chart')) {
+      const c = document.createElement('canvas');
+      c.id = 'valuation-chart';
+      document.getElementById('valuation-chart-container').appendChild(c);
+    }
+  
+    if (window.chartInstance) window.chartInstance.destroy();
+  
+    window.chartInstance = new Chart(document.getElementById('valuation-chart'), {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          label: 'Assessed Market Value',
+          data,
+          borderColor: '#0072ce',
+          backgroundColor: 'rgba(0,114,206,0.1)',
+          fill: true,
+          tension: 0.25
+        }]
+      },
+      options: { responsive: true, scales: { y: { beginAtZero: false } } }
+    });
+  }
+  
+  function renderTable (rows) {
+    const container = document.getElementById('valuation-table-container');
+    let html = `<table><thead><tr>
+      <th>Year</th><th>Market Value</th><th>Taxable Land</th><th>Taxable Improvement</th>
+      <th>Exempt Land</th><th>Exempt Improvement</th>
+    </tr></thead><tbody>`;
+  
+    rows.slice().reverse().forEach(r => {
+      html += `<tr>
+        <td>${r.year}</td>
+        <td>${fmt.format(r.market_value)}</td>
+        <td>${fmt.format(r.land_taxable)}</td>
+        <td>${fmt.format(r.improvement_taxable)}</td>
+        <td>${fmt.format(r.land_exempt)}</td>
+        <td>${fmt.format(r.improvement_exempt)}</td>
+      </tr>`;
+    });
+  
+    html += '</tbody></table>';
+    container.innerHTML = html;
+  }

--- a/widget/style.css
+++ b/widget/style.css
@@ -1,0 +1,44 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@600&family=Open+Sans&display=swap');
+
+body {
+  margin: 0;
+  font-family: 'Open Sans', sans-serif;
+  background: #f5f5f5;
+  color: #222;
+}
+
+h1, h2, h3, h4, h5 {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 600;
+  color: #222;
+}
+
+.widget-container {
+  background: #fff;
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+}
+
+.widget-header { display: flex; flex-direction: column; gap: .75rem; }
+.widget-header h2 { font-size: 1.25rem; margin: 0; }
+
+.opa-input { display: flex; gap: .5rem; align-items: center; }
+.opa-input input {
+  flex: 1; padding: .5rem; border: 1px solid #ccc; border-radius: 4px;
+}
+.opa-input button {
+  background: #0f4d90; color: #fff; padding: .5rem 1rem; border: none;
+  border-radius: 4px; cursor: pointer; transition: opacity .2s;
+}
+.opa-input button:disabled { opacity: .6; cursor: wait; }
+
+.valuation-summary { margin-top: 2rem; }
+#valuation-chart { width: 100%; height: 300px; }
+#valuation-table-container { margin-top: 1.5rem; }
+
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: .75rem; border-bottom: 1px solid #ddd; text-align: left; }
+th { background: #f0f0f0; }


### PR DESCRIPTION
Adds a standalone “Property Historical Assessment Viewer” that looks up an OPA ID, fetches live assessment history, and shows a line chart + breakdown table.

# Description

A stand-alone “Property Historical Assessment Viewer” widget so assessors (or anyone) can paste an OPA ID and instantly see the parcel’s assessment history without navigating the full Mass-Appraisal dashboard.

Speeds up parcel-level QA/QC; no need to bounce between Atlas or CSV exports.

Resolves #\[issue\]

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Small fix/change
- [ ] Documentation

## What should the reviewer know?

1. cd docs/assessment-viewer && python -m http.server 8000 (or open via Live Server).

2. Navigate to http://localhost:8000/index.html.

3. Enter a real OPA ID, e.g. 884265200.

4. Expect a blue line chart (market value per year) and a six-column table.

5. Try an invalid ID – should show an alert “No record found” and keep previous data cleared.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a `gcloud` command to upload to GCP)._

- [ ] No action required
- [ ] Actions required (specified below)
